### PR TITLE
[processor][paris] Ignore attributes unsupported by device SDK version

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -5,7 +5,7 @@ rootProject.ext {
     TARGET_SDK_VERSION = 27
     COMPILE_SDK_VERSION = 27
     MIN_SDK_VERSION = 16
-    SAMPLE_MIN_SDK_VERSION = 21
+    SAMPLE_MIN_SDK_VERSION = 16
 
     // Keep these alphabetized
     CONSTRAINT_LAYOUT_VERSION = '1.1.0'
@@ -21,19 +21,20 @@ rootProject.ext {
 
     deps = [
             // Keep these alphabetized
-            appcompatV7     : "com.android.support:appcompat-v7:$SUPPORT_LIBS_VERSION",
-            constraintLayout: "com.android.support.constraint:constraint-layout:$CONSTRAINT_LAYOUT_VERSION",
-            espresso        : "com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION",
-            javaPoet        : "com.squareup:javapoet:$JAVAPOET_VERSION",
-            junit           : "junit:junit:$JUNIT_VERSION",
-            kotlin          : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION",
-            kotlinReflect   : "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION",
-            kotlinPoet      : "com.squareup:kotlinpoet:$KOTLINPOET_VERSION",
-            kotlinTest      : "io.kotlintest:kotlintest:$KOTLIN_TEST_VERSION",
-            mockitoCore     : "org.mockito:mockito-core:$MOCKITO_VERSION",
-            mockitoAndroid  : "org.mockito:mockito-android:$MOCKITO_VERSION",
-            robolectric     : "org.robolectric:robolectric:$ROBOLECTRIC_VERSION",
-            supportV4       : "com.android.support:support-v4:$SUPPORT_LIBS_VERSION",
-            testingCompile  : "com.google.testing.compile:compile-testing:$TESTING_COMPILE_VERSION",
+            androidAnnotations: "com.android.support:support-annotations:$SUPPORT_LIBS_VERSION",
+            appcompatV7       : "com.android.support:appcompat-v7:$SUPPORT_LIBS_VERSION",
+            constraintLayout  : "com.android.support.constraint:constraint-layout:$CONSTRAINT_LAYOUT_VERSION",
+            espresso          : "com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION",
+            javaPoet          : "com.squareup:javapoet:$JAVAPOET_VERSION",
+            junit             : "junit:junit:$JUNIT_VERSION",
+            kotlin            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION",
+            kotlinReflect     : "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION",
+            kotlinPoet        : "com.squareup:kotlinpoet:$KOTLINPOET_VERSION",
+            kotlinTest        : "io.kotlintest:kotlintest:$KOTLIN_TEST_VERSION",
+            mockitoCore       : "org.mockito:mockito-core:$MOCKITO_VERSION",
+            mockitoAndroid    : "org.mockito:mockito-android:$MOCKITO_VERSION",
+            robolectric       : "org.robolectric:robolectric:$ROBOLECTRIC_VERSION",
+            supportV4         : "com.android.support:support-v4:$SUPPORT_LIBS_VERSION",
+            testingCompile    : "com.google.testing.compile:compile-testing:$TESTING_COMPILE_VERSION",
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ POM_DEVELOPER_ID=airbnb
 POM_DEVELOPER_NAME=Airbnb
 POM_DEVELOPER_EMAIL=android@airbnb.com
 POM_INCEPTION_YEAR=2017
+
+org.gradle.configureondemand=false

--- a/paris-processor/build.gradle
+++ b/paris-processor/build.gradle
@@ -9,6 +9,7 @@ targetCompatibility = rootProject.JAVA_TARGET_VERSION
 dependencies {
     implementation project(':paris-annotations')
 
+    implementation deps.androidAnnotations
     implementation deps.javaPoet
     implementation deps.kotlinPoet
     implementation deps.kotlin

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/framework/AndroidClassNames.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/framework/AndroidClassNames.kt
@@ -3,6 +3,7 @@ package com.airbnb.paris.processor.framework
 internal object AndroidClassNames {
 
     val ATTRIBUTE_SET = "android.util.AttributeSet".className()
+    val BUILD = "android.os.Build".className()
     val R = "android.R".className()
     val CONTEXT = "android.content.Context".className()
     val RESOURCES = "android.content.res.Resources".className()

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/framework/JavaPoetExtensions.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/framework/JavaPoetExtensions.kt
@@ -40,6 +40,7 @@ internal fun MethodSpec.Builder.controlFlow(controlFlow: String, arg: Any, block
     controlFlow(controlFlow, arrayOf(arg), block)
 }
 
+// TODO This interface is confusing because unless `args` is explicitly `Array<Any>` then it's the other controlFlow function that gets called, which usually results in an error.
 internal fun MethodSpec.Builder.controlFlow(controlFlow: String, args: Array<Any> = emptyArray(), block: MethodSpec.Builder.() -> Unit) {
     beginControlFlow(controlFlow, *args)
     block()

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/models/AttrInfo.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/models/AttrInfo.kt
@@ -1,5 +1,6 @@
 package com.airbnb.paris.processor.models
 
+import android.support.annotation.RequiresApi
 import com.airbnb.paris.annotations.Attr
 import com.airbnb.paris.processor.Format
 import com.airbnb.paris.processor.ParisProcessor
@@ -61,6 +62,13 @@ internal class AttrInfoExtractor(
         val javadoc = JavaCodeBlock.of("@see \$T#\$N(\$T)", enclosingElement, name, targetType)
         val kdoc = KotlinCodeBlock.of("@see %T.%N", enclosingElement, name)
 
+        // We rely on the `RequiresApi` Android annotation to disable certain attributes based on the Android SDK version.
+        // 1 is the default since that's the minimum version.
+        val requiresApi = element.getAnnotation(RequiresApi::class.java)?.let {
+            // value is an alias of api, so we give precedence to api.
+            if (it.api > 1) it.api else it.value
+        } ?: 1
+
         return AttrInfo(
             element,
             targetType,
@@ -68,7 +76,8 @@ internal class AttrInfoExtractor(
             styleableResId,
             defaultValueResId,
             javadoc,
-            kdoc
+            kdoc,
+            requiresApi
         )
     }
 }
@@ -84,5 +93,6 @@ internal class AttrInfo(
     val styleableResId: AndroidResourceId,
     val defaultValueResId: AndroidResourceId?,
     val javadoc: JavaCodeBlock,
-    val kdoc: KotlinCodeBlock
+    val kdoc: KotlinCodeBlock,
+    val requiresApi: Int
 ) : SkyMethodModel(element)

--- a/paris-test/src/test/java/com/airbnb/paris/test/ParisProcessorTest.kt
+++ b/paris-test/src/test/java/com/airbnb/paris/test/ParisProcessorTest.kt
@@ -52,6 +52,16 @@ class ParisProcessorTest {
     }
 
     @Test
+    fun attr_requires_api() {
+        assertCase("attr_requires_api")
+    }
+
+    @Test
+    fun attr_requires_api_default_value() {
+        assertCase("attr_requires_api_default_value")
+    }
+
+    @Test
     fun attrs() {
         assertCase("attrs")
     }

--- a/paris-test/src/test/resources/attr_requires_api/MyView.java
+++ b/paris-test/src/test/resources/attr_requires_api/MyView.java
@@ -1,0 +1,39 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.AnyRes;
+import android.support.annotation.BoolRes;
+import android.support.annotation.ColorInt;
+import android.support.annotation.Px;
+import android.support.annotation.RequiresApi;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.airbnb.paris.annotations.Attr;
+import com.airbnb.paris.annotations.Fraction;
+import com.airbnb.paris.annotations.LayoutDimension;
+import com.airbnb.paris.annotations.Styleable;
+
+@Styleable("Formats")
+public class MyView extends View {
+
+    public MyView(Context context) {
+        super(context);
+    }
+
+    public MyView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MyView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Attr(R2.styleable.Formats_formatBoolean)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    public void formatBoolean(boolean value) {}
+}

--- a/paris-test/src/test/resources/attr_requires_api/MyViewStyleApplier.java
+++ b/paris-test/src/test/resources/attr_requires_api/MyViewStyleApplier.java
@@ -1,0 +1,106 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Build;
+import android.support.annotation.BoolRes;
+import android.support.annotation.UiThread;
+import android.view.ViewStyleApplier;
+import com.airbnb.paris.StyleApplier;
+import com.airbnb.paris.styles.Style;
+import com.airbnb.paris.typed_array_wrappers.TypedArrayWrapper;
+import java.lang.Override;
+
+@UiThread
+public final class MyViewStyleApplier extends StyleApplier<MyView, MyView> {
+  public MyViewStyleApplier(MyView view) {
+    super(view);
+  }
+
+  @Override
+  protected void applyParent(Style style) {
+    ViewStyleApplier applier = new ViewStyleApplier(getView());
+    applier.setDebugListener(getDebugListener());
+    applier.apply(style);
+  }
+
+  @Override
+  protected int[] attributes() {
+    return R.styleable.Formats;
+  }
+
+  @Override
+  protected void processStyleableFields(Style style, TypedArrayWrapper a) {
+    Context context = getView().getContext();
+    Resources res = context.getResources();
+  }
+
+  @Override
+  protected void processAttributes(Style style, TypedArrayWrapper a) {
+    Context context = getView().getContext();
+    Resources res = context.getResources();
+    if (Build.VERSION.SDK_INT >= 21) {
+      if (a.hasValue(R.styleable.Formats_formatBoolean)) {
+        getProxy().formatBoolean(a.getBoolean(R.styleable.Formats_formatBoolean));
+      }
+    }
+  }
+
+  public StyleBuilder builder() {
+    return new StyleBuilder(this);
+  }
+
+  /**
+   * Empty style */
+  public void applyDefault() {
+  }
+
+  /**
+   * For debugging */
+  public static void assertStylesContainSameAttributes(Context context) {
+  }
+
+  public abstract static class BaseStyleBuilder<B extends BaseStyleBuilder<B, A>, A extends StyleApplier<?, ?>> extends ViewStyleApplier.BaseStyleBuilder<B, A> {
+    public BaseStyleBuilder(A applier) {
+      super(applier);
+    }
+
+    public BaseStyleBuilder() {
+    }
+
+    /**
+     * @see MyView#formatBoolean(boolean) */
+    public B formatBoolean(boolean value) {
+      getBuilder().put(R.styleable.Formats[R.styleable.Formats_formatBoolean], value);
+      return (B) this;
+    }
+
+    /**
+     * @see MyView#formatBoolean(boolean) */
+    public B formatBooleanRes(@BoolRes int resId) {
+      getBuilder().putRes(R.styleable.Formats[R.styleable.Formats_formatBoolean], resId);
+      return (B) this;
+    }
+
+    public B applyTo(MyView view) {
+      new MyViewStyleApplier(view).apply(build());
+      return (B) this;
+    }
+  }
+
+  @UiThread
+  public static final class StyleBuilder extends BaseStyleBuilder<StyleBuilder, MyViewStyleApplier> {
+    public StyleBuilder(MyViewStyleApplier applier) {
+      super(applier);
+    }
+
+    public StyleBuilder() {
+    }
+
+    /**
+     * Empty style */
+    public StyleBuilder addDefault() {
+      return this;
+    }
+  }
+}

--- a/paris-test/src/test/resources/attr_requires_api/Paris.java
+++ b/paris-test/src/test/resources/attr_requires_api/Paris.java
@@ -1,0 +1,77 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewGroupStyleApplier;
+import android.view.ViewStyleApplier;
+import android.widget.ImageView;
+import android.widget.ImageViewStyleApplier;
+import android.widget.TextView;
+import android.widget.TextViewStyleApplier;
+import com.airbnb.paris.spannables.SpannableBuilder;
+
+public final class Paris {
+  public static ImageViewStyleApplier style(ImageView view) {
+    return new ImageViewStyleApplier(view);
+  }
+
+  public static ImageViewStyleApplier.StyleBuilder styleBuilder(ImageView view) {
+    return new ImageViewStyleApplier.StyleBuilder(new ImageViewStyleApplier(view));
+  }
+
+  public static MyOtherViewStyleApplier style(MyOtherView view) {
+    return new MyOtherViewStyleApplier(view);
+  }
+
+  public static MyOtherViewStyleApplier.StyleBuilder styleBuilder(MyOtherView view) {
+    return new MyOtherViewStyleApplier.StyleBuilder(new MyOtherViewStyleApplier(view));
+  }
+
+  public static MyViewStyleApplier style(MyView view) {
+    return new MyViewStyleApplier(view);
+  }
+
+  public static MyViewStyleApplier.StyleBuilder styleBuilder(MyView view) {
+    return new MyViewStyleApplier.StyleBuilder(new MyViewStyleApplier(view));
+  }
+
+  public static TextViewStyleApplier style(TextView view) {
+    return new TextViewStyleApplier(view);
+  }
+
+  public static TextViewStyleApplier.StyleBuilder styleBuilder(TextView view) {
+    return new TextViewStyleApplier.StyleBuilder(new TextViewStyleApplier(view));
+  }
+
+  public static ViewGroupStyleApplier style(ViewGroup view) {
+    return new ViewGroupStyleApplier(view);
+  }
+
+  public static ViewGroupStyleApplier.StyleBuilder styleBuilder(ViewGroup view) {
+    return new ViewGroupStyleApplier.StyleBuilder(new ViewGroupStyleApplier(view));
+  }
+
+  public static ViewStyleApplier style(View view) {
+    return new ViewStyleApplier(view);
+  }
+
+  public static ViewStyleApplier.StyleBuilder styleBuilder(View view) {
+    return new ViewStyleApplier.StyleBuilder(new ViewStyleApplier(view));
+  }
+
+  public static SpannableBuilder spannableBuilder() {
+    return new SpannableBuilder();
+  }
+
+  /**
+   * For debugging */
+  public static void assertStylesContainSameAttributes(Context context) {
+    ImageViewStyleApplier.assertStylesContainSameAttributes(context);
+    MyOtherViewStyleApplier.assertStylesContainSameAttributes(context);
+    MyViewStyleApplier.assertStylesContainSameAttributes(context);
+    TextViewStyleApplier.assertStylesContainSameAttributes(context);
+    ViewGroupStyleApplier.assertStylesContainSameAttributes(context);
+    ViewStyleApplier.assertStylesContainSameAttributes(context);
+  }
+}

--- a/paris-test/src/test/resources/attr_requires_api_default_value/MyView.java
+++ b/paris-test/src/test/resources/attr_requires_api_default_value/MyView.java
@@ -1,0 +1,39 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.AnyRes;
+import android.support.annotation.BoolRes;
+import android.support.annotation.ColorInt;
+import android.support.annotation.Px;
+import android.support.annotation.RequiresApi;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.airbnb.paris.annotations.Attr;
+import com.airbnb.paris.annotations.Fraction;
+import com.airbnb.paris.annotations.LayoutDimension;
+import com.airbnb.paris.annotations.Styleable;
+
+@Styleable("Formats")
+public class MyView extends View {
+
+    public MyView(Context context) {
+        super(context);
+    }
+
+    public MyView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MyView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Attr(value = R2.styleable.Formats_formatBoolean, defaultValue = R2.bool.format_boolean)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    public void formatBoolean(boolean value) {}
+}

--- a/paris-test/src/test/resources/attr_requires_api_default_value/MyViewStyleApplier.java
+++ b/paris-test/src/test/resources/attr_requires_api_default_value/MyViewStyleApplier.java
@@ -1,0 +1,114 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Build;
+import android.support.annotation.BoolRes;
+import android.support.annotation.UiThread;
+import android.view.ViewStyleApplier;
+import com.airbnb.paris.StyleApplier;
+import com.airbnb.paris.styles.Style;
+import com.airbnb.paris.typed_array_wrappers.TypedArrayWrapper;
+import java.lang.Override;
+
+@UiThread
+public final class MyViewStyleApplier extends StyleApplier<MyView, MyView> {
+  public MyViewStyleApplier(MyView view) {
+    super(view);
+  }
+
+  @Override
+  protected void applyParent(Style style) {
+    ViewStyleApplier applier = new ViewStyleApplier(getView());
+    applier.setDebugListener(getDebugListener());
+    applier.apply(style);
+  }
+
+  @Override
+  protected int[] attributes() {
+    return R.styleable.Formats;
+  }
+
+  @Override
+  public int[] attributesWithDefaultValue() {
+    return new int[] {R.styleable.Formats_formatBoolean,};
+  }
+
+  @Override
+  protected void processStyleableFields(Style style, TypedArrayWrapper a) {
+    Context context = getView().getContext();
+    Resources res = context.getResources();
+  }
+
+  @Override
+  protected void processAttributes(Style style, TypedArrayWrapper a) {
+    Context context = getView().getContext();
+    Resources res = context.getResources();
+    if (Build.VERSION.SDK_INT >= 21) {
+      if (a.hasValue(R.styleable.Formats_formatBoolean)) {
+        getProxy().formatBoolean(a.getBoolean(R.styleable.Formats_formatBoolean));
+      }
+      else if (style.getShouldApplyDefaults()) {
+        getProxy().formatBoolean(res.getBoolean(R.bool.format_boolean));
+      }
+    }
+  }
+
+  public StyleBuilder builder() {
+    return new StyleBuilder(this);
+  }
+
+  /**
+   * Empty style */
+  public void applyDefault() {
+  }
+
+  /**
+   * For debugging */
+  public static void assertStylesContainSameAttributes(Context context) {
+  }
+
+  public abstract static class BaseStyleBuilder<B extends BaseStyleBuilder<B, A>, A extends StyleApplier<?, ?>> extends ViewStyleApplier.BaseStyleBuilder<B, A> {
+    public BaseStyleBuilder(A applier) {
+      super(applier);
+    }
+
+    public BaseStyleBuilder() {
+    }
+
+    /**
+     * @see MyView#formatBoolean(boolean) */
+    public B formatBoolean(boolean value) {
+      getBuilder().put(R.styleable.Formats[R.styleable.Formats_formatBoolean], value);
+      return (B) this;
+    }
+
+    /**
+     * @see MyView#formatBoolean(boolean) */
+    public B formatBooleanRes(@BoolRes int resId) {
+      getBuilder().putRes(R.styleable.Formats[R.styleable.Formats_formatBoolean], resId);
+      return (B) this;
+    }
+
+    public B applyTo(MyView view) {
+      new MyViewStyleApplier(view).apply(build());
+      return (B) this;
+    }
+  }
+
+  @UiThread
+  public static final class StyleBuilder extends BaseStyleBuilder<StyleBuilder, MyViewStyleApplier> {
+    public StyleBuilder(MyViewStyleApplier applier) {
+      super(applier);
+    }
+
+    public StyleBuilder() {
+    }
+
+    /**
+     * Empty style */
+    public StyleBuilder addDefault() {
+      return this;
+    }
+  }
+}

--- a/paris-test/src/test/resources/attr_requires_api_default_value/Paris.java
+++ b/paris-test/src/test/resources/attr_requires_api_default_value/Paris.java
@@ -1,0 +1,77 @@
+package com.airbnb.paris.test;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewGroupStyleApplier;
+import android.view.ViewStyleApplier;
+import android.widget.ImageView;
+import android.widget.ImageViewStyleApplier;
+import android.widget.TextView;
+import android.widget.TextViewStyleApplier;
+import com.airbnb.paris.spannables.SpannableBuilder;
+
+public final class Paris {
+  public static ImageViewStyleApplier style(ImageView view) {
+    return new ImageViewStyleApplier(view);
+  }
+
+  public static ImageViewStyleApplier.StyleBuilder styleBuilder(ImageView view) {
+    return new ImageViewStyleApplier.StyleBuilder(new ImageViewStyleApplier(view));
+  }
+
+  public static MyOtherViewStyleApplier style(MyOtherView view) {
+    return new MyOtherViewStyleApplier(view);
+  }
+
+  public static MyOtherViewStyleApplier.StyleBuilder styleBuilder(MyOtherView view) {
+    return new MyOtherViewStyleApplier.StyleBuilder(new MyOtherViewStyleApplier(view));
+  }
+
+  public static MyViewStyleApplier style(MyView view) {
+    return new MyViewStyleApplier(view);
+  }
+
+  public static MyViewStyleApplier.StyleBuilder styleBuilder(MyView view) {
+    return new MyViewStyleApplier.StyleBuilder(new MyViewStyleApplier(view));
+  }
+
+  public static TextViewStyleApplier style(TextView view) {
+    return new TextViewStyleApplier(view);
+  }
+
+  public static TextViewStyleApplier.StyleBuilder styleBuilder(TextView view) {
+    return new TextViewStyleApplier.StyleBuilder(new TextViewStyleApplier(view));
+  }
+
+  public static ViewGroupStyleApplier style(ViewGroup view) {
+    return new ViewGroupStyleApplier(view);
+  }
+
+  public static ViewGroupStyleApplier.StyleBuilder styleBuilder(ViewGroup view) {
+    return new ViewGroupStyleApplier.StyleBuilder(new ViewGroupStyleApplier(view));
+  }
+
+  public static ViewStyleApplier style(View view) {
+    return new ViewStyleApplier(view);
+  }
+
+  public static ViewStyleApplier.StyleBuilder styleBuilder(View view) {
+    return new ViewStyleApplier.StyleBuilder(new ViewStyleApplier(view));
+  }
+
+  public static SpannableBuilder spannableBuilder() {
+    return new SpannableBuilder();
+  }
+
+  /**
+   * For debugging */
+  public static void assertStylesContainSameAttributes(Context context) {
+    ImageViewStyleApplier.assertStylesContainSameAttributes(context);
+    MyOtherViewStyleApplier.assertStylesContainSameAttributes(context);
+    MyViewStyleApplier.assertStylesContainSameAttributes(context);
+    TextViewStyleApplier.assertStylesContainSameAttributes(context);
+    ViewGroupStyleApplier.assertStylesContainSameAttributes(context);
+    ViewStyleApplier.assertStylesContainSameAttributes(context);
+  }
+}

--- a/paris/src/main/java/com/airbnb/paris/proxies/ImageViewProxy.kt
+++ b/paris/src/main/java/com/airbnb/paris/proxies/ImageViewProxy.kt
@@ -3,6 +3,7 @@ package com.airbnb.paris.proxies
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.os.Build
+import android.support.annotation.RequiresApi
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 
@@ -22,10 +23,9 @@ class ImageViewProxy(view: ImageView) : BaseProxy<ImageViewProxy, ImageView>(vie
     }
 
     @Attr(R2.styleable.Paris_ImageView_android_tint)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     fun setTint(color: ColorStateList?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.imageTintList = color
-        }
+        view.imageTintList = color
     }
 
     @Attr(R2.styleable.Paris_ImageView_android_src)

--- a/paris/src/main/java/com/airbnb/paris/proxies/TextViewProxy.kt
+++ b/paris/src/main/java/com/airbnb/paris/proxies/TextViewProxy.kt
@@ -5,6 +5,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.support.annotation.Px
+import android.support.annotation.RequiresApi
 import android.text.InputType
 import android.text.TextUtils
 import android.text.method.PasswordTransformationMethod
@@ -93,10 +94,9 @@ class TextViewProxy(view: TextView) : BaseProxy<TextViewProxy, TextView>(view) {
     }
 
     @Attr(R2.styleable.Paris_TextView_android_letterSpacing)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     fun setLetterSpacing(letterSpacing: Float) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.letterSpacing = letterSpacing
-        }
+        view.letterSpacing = letterSpacing
     }
 
     @Attr(R2.styleable.Paris_TextView_android_lines)

--- a/paris/src/main/java/com/airbnb/paris/proxies/ViewProxy.kt
+++ b/paris/src/main/java/com/airbnb/paris/proxies/ViewProxy.kt
@@ -152,13 +152,13 @@ class ViewProxy(view: View) : BaseProxy<ViewProxy, View>(view) {
     }
 
     @Attr(R2.styleable.Paris_View_android_layout_marginEnd)
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     fun setLayoutMarginEnd(@Px marginEnd: Int) {
         this.marginEnd = marginEnd
     }
 
     @Attr(R2.styleable.Paris_View_android_layout_marginStart)
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     fun setLayoutMarginStart(@Px marginStart: Int) {
         this.marginStart = marginStart
     }
@@ -206,16 +206,16 @@ class ViewProxy(view: View) : BaseProxy<ViewProxy, View>(view) {
         view.contentDescription = contentDescription
     }
 
+    // TODO Fix Samsung bug, see https://github.com/airbnb/paris/issues/70#issuecomment-421332864
     @Attr(R2.styleable.Paris_View_android_elevation)
     fun setElevation(@Px elevation: Int) {
         ViewCompat.setElevation(view, elevation.toFloat())
     }
 
     @Attr(R2.styleable.Paris_View_android_foreground)
+    @RequiresApi(Build.VERSION_CODES.M)
     fun setForeground(drawable: Drawable?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            view.foreground = drawable
-        }
+        view.foreground = drawable
     }
 
     @Attr(R2.styleable.Paris_View_android_minHeight)
@@ -264,27 +264,26 @@ class ViewProxy(view: View) : BaseProxy<ViewProxy, View>(view) {
     }
 
     @Attr(R2.styleable.Paris_View_android_paddingEnd)
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     fun setPaddingEnd(@Px padding: Int) {
         view.setPaddingEnd(padding)
     }
 
     @Attr(R2.styleable.Paris_View_android_paddingStart)
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     fun setPaddingStart(@Px padding: Int) {
         view.setPaddingStart(padding)
     }
 
     @Attr(R2.styleable.Paris_View_android_stateListAnimator)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     fun setStateListAnimator(@AnyRes animatorRes: Int) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            val animator = if (animatorRes != 0) {
-                AnimatorInflater.loadStateListAnimator(view.context, animatorRes)
-            } else {
-                null
-            }
-            view.stateListAnimator = animator
+        val animator = if (animatorRes != 0) {
+            AnimatorInflater.loadStateListAnimator(view.context, animatorRes)
+        } else {
+            null
         }
+        view.stateListAnimator = animator
     }
 
     @Attr(R2.styleable.Paris_View_android_visibility)

--- a/paris/src/testDebug/java/com/airbnb/paris/proxies/ViewStyleApplierTest.kt
+++ b/paris/src/testDebug/java/com/airbnb/paris/proxies/ViewStyleApplierTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.support.v4.content.ContextCompat
 import android.view.View
 import android.view.ViewGroup
@@ -17,6 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class ViewStyleApplierTest {
@@ -55,8 +57,8 @@ class ViewStyleApplierTest {
         view.backgroundTintList = ContextCompat.getColorStateList(context, android.R.color.black)
         applier.apply(builder.backgroundTintRes(android.R.color.holo_red_dark).build())
         assertEquals(
-                ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
-                view.backgroundTintList
+            ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
+            view.backgroundTintList
         )
     }
 
@@ -65,8 +67,8 @@ class ViewStyleApplierTest {
         view.backgroundTintList = ContextCompat.getColorStateList(context, android.R.color.black)
         applier.apply(builder.backgroundTint(ContextCompat.getColor(context, android.R.color.holo_red_dark)).build())
         assertEquals(
-                ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
-                view.backgroundTintList
+            ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
+            view.backgroundTintList
         )
     }
 
@@ -82,8 +84,8 @@ class ViewStyleApplierTest {
         view.backgroundTintList = ContextCompat.getColorStateList(context, android.R.color.black)
         applier.apply(builder.backgroundTint(ContextCompat.getColorStateList(context, android.R.color.holo_red_dark)).build())
         assertEquals(
-                ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
-                view.backgroundTintList
+            ContextCompat.getColorStateList(context, android.R.color.holo_red_dark),
+            view.backgroundTintList
         )
     }
 
@@ -99,8 +101,8 @@ class ViewStyleApplierTest {
         view.backgroundTintMode = PorterDuff.Mode.SRC_OVER
         applier.apply(builder.backgroundTintMode(ViewProxy.PORTERDUFF_MODE_ADD).build())
         assertEquals(
-                PorterDuff.Mode.ADD,
-                view.backgroundTintMode
+            PorterDuff.Mode.ADD,
+            view.backgroundTintMode
         )
     }
 
@@ -152,6 +154,17 @@ class ViewStyleApplierTest {
     }
 
     @Test
+    @Config(sdk = [(Build.VERSION_CODES.JELLY_BEAN)])
+    fun layout_marginEnd_requiresApi() {
+        // layout_marginEnd requires JELLY_BEAN_MR1 (17) so here the attribute should be ignored.
+        applier.apply(viewStyle {
+            layoutMarginEnd(10)
+        })
+        // The margin doesn't get set so the layout parameters should still be null.
+        assertNull(view.layoutParams)
+    }
+
+    @Test
     fun layout_marginStart_precedence() {
         applier.apply(viewStyle {
             layoutMarginStart(20)
@@ -159,6 +172,17 @@ class ViewStyleApplierTest {
         })
         val layoutParams = view.layoutParams as ViewGroup.MarginLayoutParams
         assertEquals(20, layoutParams.marginStart)
+    }
+
+    @Test
+    @Config(sdk = [(Build.VERSION_CODES.JELLY_BEAN)])
+    fun layout_marginStart_requiresApi() {
+        // layout_marginStart requires JELLY_BEAN_MR1 (17) so here the attribute should be ignored.
+        applier.apply(viewStyle {
+            layoutMarginStart(10)
+        })
+        // The margin doesn't get set so the layout parameters should still be null.
+        assertNull(view.layoutParams)
     }
 
     @Test

--- a/sample/src/main/java/com/airbnb/paris/sample/SectionView.kt
+++ b/sample/src/main/java/com/airbnb/paris/sample/SectionView.kt
@@ -107,6 +107,8 @@ class SectionView : FrameLayout {
             // Set each padding value independently so that they can be overridden in other styles.
             paddingBottomRes(R.dimen.space4)
             paddingEndRes(R.dimen.space4)
+            paddingLeftRes(R.dimen.space4)
+            paddingRightRes(R.dimen.space4)
             paddingStartRes(R.dimen.space4)
             paddingTopRes(R.dimen.space4)
             titleStyle(DEFAULT_TITLE_STYLE)


### PR DESCRIPTION
@kristiyanP I believe this fixes #70. Could you test this with your use case before I merge it in? Thanks.

I noticed that `Paris.assertStylesContainSameAttributes()` also crashes if some of the style attributes aren't supported by the device SDK version, so I'll look into fixing that shortly as well.

@plnice the Samsung elevation bug you mentioned (https://github.com/airbnb/paris/issues/70#issuecomment-421332864) is going to be trickier. Would you mind opening a new issue for it? Any details you have will be useful.