### PR TITLE
Add newline at end of kdoc and javadoc

### DIFF
--- a/paris-processor/src/main/java/com/airbnb/paris/processor/models/AttrInfo.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/models/AttrInfo.kt
@@ -59,11 +59,11 @@ internal class AttrInfoExtractor(
 
         val enclosingElement = element.enclosingElement as TypeElement
         val name = element.simpleName.toString()
-        val javadoc = JavaCodeBlock.of("@see \$T#\$N(\$T)", enclosingElement, name, targetType)
+        val javadoc = JavaCodeBlock.of("@see \$T#\$N(\$T)\n", enclosingElement, name, targetType)
         // internal functions have a '$' in their name which creates a kdoc error. We could escape it but the part after the '$' is meant for
         // obfuscation anyway so not using it should result in clearer documentation.
         val kdocName = name.substringBefore('$')
-        val kdoc = KotlinCodeBlock.of("@see %T.%N", enclosingElement, kdocName)
+        val kdoc = KotlinCodeBlock.of("@see %T.%N\n", enclosingElement, kdocName)
 
         // We rely on the `RequiresApi` Android annotation to disable certain attributes based on the Android SDK version.
         // 1 is the default since that's the minimum version.

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/models/StyleCompanionPropertyInfo.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/models/StyleCompanionPropertyInfo.kt
@@ -49,8 +49,8 @@ internal class StyleCompanionPropertyInfoExtractor(processor: ParisProcessor)
 
         val formattedName = ParisProcessorUtils.reformatStyleFieldOrMethodName(elementName)
 
-        val javadoc = JavaCodeBlock.of("@see \$T#\$N", enclosingElement, elementName)
-        val kdoc = KotlinCodeBlock.of("@see %T.%N", enclosingElement, elementName)
+        val javadoc = JavaCodeBlock.of("@see \$T#\$N\n", enclosingElement, elementName)
+        val kdoc = KotlinCodeBlock.of("@see %T.%N\n", enclosingElement, elementName)
 
         val styleInfo = StyleCompanionPropertyInfo(
             element,

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/models/StyleStaticMethodInfo.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/models/StyleStaticMethodInfo.kt
@@ -33,8 +33,8 @@ internal class StyleStaticMethodInfoExtractor(processor: ParisProcessor)
         // TODO Check that the target type is a builder
         val targetType = element.parameters[0].asType()
 
-        val javadoc = JavaCodeBlock.of("@see \$T#\$N(\$T)", enclosingElement, elementName, targetType)
-        val kdoc = KotlinCodeBlock.of("@see %T.%N", enclosingElement, elementName)
+        val javadoc = JavaCodeBlock.of("@see \$T#\$N(\$T)\n", enclosingElement, elementName, targetType)
+        val kdoc = KotlinCodeBlock.of("@see %T.%N\n", enclosingElement, elementName)
 
         return StyleStaticMethodInfo(
             element,

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/writers/ParisJavaClass.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/writers/ParisJavaClass.kt
@@ -64,7 +64,7 @@ internal class ParisJavaClass(
 
         // TODO Should the method take in an Activity since anything else seems to screw up view inflation?
         method("assertStylesContainSameAttributes") {
-            addJavadoc("For debugging")
+            addJavadoc("For debugging\n")
             public()
             static()
             addParameter(AndroidClassNames.CONTEXT, "context")

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/writers/StyleApplierJavaClass.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/writers/StyleApplierJavaClass.kt
@@ -251,7 +251,7 @@ internal class StyleApplierJavaClass(
         }
 
         method("assertStylesContainSameAttributes") {
-            addJavadoc("For debugging")
+            addJavadoc("For debugging\n")
             public()
             static()
             addParameter(AndroidClassNames.CONTEXT, "context")


### PR DESCRIPTION
Previously:
```java
  /**
   * @see SectionView#setTitleText(CharSequence)*/
  public B titleText(@Nullable CharSequence value) {
      getBuilder().put(R.styleable.SectionView[R.styleable.SectionView_titleText], value);
      return (B) this;
  }
```
Fixed to be:
```java
  /**
   * @see SectionView#setTitleText(CharSequence)
   */
  public B titleText(@Nullable CharSequence value) {
      getBuilder().put(R.styleable.SectionView[R.styleable.SectionView_titleText], value);
      return (B) this;
  }
```