### PR TITLE
Add Kotlin nullable type instead of Nullable annotation

### DIFF
--- a/paris-processor/src/main/java/com/airbnb/paris/processor/Format.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/Format.kt
@@ -139,6 +139,11 @@ internal class Format private constructor(
 
     val isColorStateListType = type == Type.COLOR_STATE_LIST
 
+    val isNullable: Boolean
+        get() {
+            return valueAnnotation == AndroidClassNames.NULLABLE
+        }
+
     val valueAnnotation: ClassName?
         get() = when (type) {
             Type.COLOR -> AndroidClassNames.COLOR_INT

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/writers/StyleExtensionsKotlinFile.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/writers/StyleExtensionsKotlinFile.kt
@@ -246,8 +246,10 @@ internal class StyleExtensionsKotlinFile(
                     addRequiresApiAnnotation(this, attr)
 
                     // TODO Make sure that this works correctly when the view code is in Kotlin and already using Kotlin types
-                    parameter("value", JavaTypeName.get(attr.targetType).toKPoet()) {
-                        attr.targetFormat.valueAnnotation?.let {
+                    parameter("value", JavaTypeName.get(attr.targetType).toKPoet().copy(nullable = attr.targetFormat.isNullable)) {
+                        // Filter out the Nullable annotation since we defer to idiomatic Kotlin by attaching
+                        // the nullability to the type.
+                        attr.targetFormat.valueAnnotation?.takeIf { it != AndroidClassNames.NULLABLE }?.let {
                             addAnnotation(it)
                         }
                     }


### PR DESCRIPTION
Was taking a look at #68 and I noticed that for generated extension functions, we add `@Nullable` annotation. I've changed it to actually mark the type as nullable in Kotlin. 

Other than that, unless I'm missing something, it looks like we already do carry over the nullability of parameters. 