### PR TITLE
Cleanup lint warnings

### DIFF
--- a/paris/build.gradle
+++ b/paris/build.gradle
@@ -20,7 +20,6 @@ android {
     }
 
     lintOptions {
-        checkAllWarnings true
         warningsAsErrors true
     }
 }

--- a/paris/build.gradle
+++ b/paris/build.gradle
@@ -18,6 +18,11 @@ android {
             includeAndroidResources = true
         }
     }
+
+    lintOptions {
+        checkAllWarnings true
+        warningsAsErrors true
+    }
 }
 
 dependencies {

--- a/paris/src/main/java/com/airbnb/paris/StyleApplierUtils.kt
+++ b/paris/src/main/java/com/airbnb/paris/StyleApplierUtils.kt
@@ -43,7 +43,7 @@ class StyleApplierUtils {
 
     companion object {
 
-        private fun getAttrNames(context: Context, attrs: IntArray, attrIndexes: Set<Int>) =
+        internal fun getAttrNames(context: Context, attrs: IntArray, attrIndexes: Set<Int>) =
             attrIndexes.map { index ->
                 try {
                     context.resources.getResourceEntryName(attrs[index])
@@ -96,7 +96,7 @@ class StyleApplierUtils {
             }
         }
 
-        private fun getMissingStyleAttributesError(view: View, style: Style, otherStyles: Set<Style>, missingAttrNames: Set<String>): String {
+        internal fun getMissingStyleAttributesError(view: View, style: Style, otherStyles: Set<Style>, missingAttrNames: Set<String>): String {
             val context = view.context
             val viewName = view.javaClass.simpleName
             val styleName = style.name(context)

--- a/paris/src/main/java/com/airbnb/paris/styles/ProgrammaticStyle.kt
+++ b/paris/src/main/java/com/airbnb/paris/styles/ProgrammaticStyle.kt
@@ -18,7 +18,7 @@ data class ProgrammaticStyle internal constructor(
     private var name: String? = null
 ) : Style {
 
-    private constructor(builder: Builder) : this(builder.attrResToValueResMap, builder.name)
+    internal constructor(builder: Builder) : this(builder.attrResToValueResMap, builder.name)
 
     data class Builder internal constructor(
         internal val attrResToValueResMap: MutableMap<Int, Any?> = HashMap(),

--- a/paris/src/main/java/com/airbnb/paris/utils/StyleBuilderFunction.java
+++ b/paris/src/main/java/com/airbnb/paris/utils/StyleBuilderFunction.java
@@ -1,8 +1,9 @@
 package com.airbnb.paris.utils;
 
 import com.airbnb.paris.StyleBuilder;
+import androidx.annotation.NonNull;
 
 public interface StyleBuilderFunction<T extends StyleBuilder> {
 
-    void invoke(T builder);
+    void invoke(@NonNull T builder);
 }


### PR DESCRIPTION
Most of the visibility changes are related to synthetic accessors. One other change is adding `@NonNull` for clarified nullability. 

Unfortunately, I'm not able to add `checkAllWarnings` as that crashes the `lint` task for some reason. The stacktrace is hard to make sense of and so I've left it for now. If you're interested in reproducing, you can checkout https://github.com/airbnb/paris/commit/1c689798edcb9373f69802af05a50291a9c29ecd and try `./gradlew check`

Part of #9 	