### PR TITLE
Add support for lineHeight in TextView

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -12,18 +12,20 @@ rootProject.ext {
     ANDROIDX_APPCOMPAT_VERSION = '1.0.0'
     ANDROIDX_CONSTRAINTLAYOUT_VERSION = '1.1.3'
     ANDROIDX_ESPRESSO_VERSION = '3.1.0'
+    ANDROIDX_TEST = "1.1.0"
     JAVAPOET_VERSION = '1.11.1'
     JUNIT_VERSION = '4.12'
     KOTLINPOET_VERSION = '1.0.0'
     KOTLIN_TEST_VERSION = '2.0.7'
     MOCKITO_VERSION = '2.23.0'
-    ROBOLECTRIC_VERSION = '3.8'
+    ROBOLECTRIC_VERSION = '4.1'
     TESTING_COMPILE_VERSION = '0.15'
 
     deps = [
             // Keep these alphabetized
             androidAnnotations: "androidx.annotation:annotation:$ANDROIDX_ANNOTATIONS_VERSION",
             appcompat         : "androidx.appcompat:appcompat:$ANDROIDX_APPCOMPAT_VERSION",
+            androidxTestCore  : "androidx.test:core:$ANDROIDX_TEST",
             constraintLayout  : "androidx.constraintlayout:constraintlayout:$ANDROIDX_CONSTRAINTLAYOUT_VERSION",
             espresso          : "androidx.test.espresso:espresso-core:$ANDROIDX_ESPRESSO_VERSION",
             javaPoet          : "com.squareup:javapoet:$JAVAPOET_VERSION",

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ POM_INCEPTION_YEAR=2017
 
 android.useAndroidX=true
 org.gradle.configureondemand=false
+android.enableUnitTestBinaryResources=true

--- a/paris/build.gradle
+++ b/paris/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     kapt project(':paris-processor')
 
+    testImplementation deps.androidxTestCore
     testImplementation deps.junit
     testImplementation deps.kotlinTest
     testImplementation deps.mockitoCore

--- a/paris/src/main/java/com/airbnb/paris/proxies/TextViewProxy.kt
+++ b/paris/src/main/java/com/airbnb/paris/proxies/TextViewProxy.kt
@@ -104,6 +104,12 @@ class TextViewProxy(view: TextView) : BaseProxy<TextViewProxy, TextView>(view) {
         view.letterSpacing = letterSpacing
     }
 
+    @Attr(R2.styleable.Paris_TextView_android_lineHeight)
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun setLineHeight(lineHeight: Int) {
+        view.lineHeight = lineHeight
+    }
+
     @Attr(R2.styleable.Paris_TextView_android_lines)
     fun setLines(lines: Int) {
         view.setLines(lines)

--- a/paris/src/main/res/values/attrs.xml
+++ b/paris/src/main/res/values/attrs.xml
@@ -57,6 +57,7 @@
         <attr name="android:fontFamily" />
         <attr name="android:gravity" />
         <attr name="android:letterSpacing" />
+        <attr name="android:lineHeight"/>
         <attr name="android:lines" />
         <attr name="android:lineSpacingExtra" />
         <attr name="android:lineSpacingMultiplier" />

--- a/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewProxyTest.kt
+++ b/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewProxyTest.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.text.InputType
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import com.airbnb.paris.utils.assertTypefaceEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -13,7 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class TextViewProxyTest {
@@ -24,7 +25,7 @@ class TextViewProxyTest {
 
     @Before
     fun setup() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         view = TextView(context)
         proxy = TextViewProxy(view)
     }
@@ -221,5 +222,14 @@ class TextViewProxyTest {
         view.compoundDrawablePadding = 0
         proxy.setDrawablePadding(100)
         assertEquals(100, view.compoundDrawablePadding)
+    }
+
+    @Config(sdk = [28])
+    @Test
+    fun setLineHeight() {
+        val lineHeight = 16
+        proxy.setLineHeight(lineHeight)
+
+        assertEquals(lineHeight, view.lineHeight)
     }
 }

--- a/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewStyleApplierTest.kt
+++ b/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewStyleApplierTest.kt
@@ -10,6 +10,7 @@ import android.text.method.PasswordTransformationMethod
 import android.view.View
 import android.widget.TextView
 import android.widget.TextViewStyleApplier
+import androidx.test.core.app.ApplicationProvider
 import com.airbnb.paris.R
 import com.airbnb.paris.utils.ShadowResourcesCompat
 import com.airbnb.paris.utils.assertTypefaceEquals
@@ -19,7 +20,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -33,7 +33,7 @@ class TextViewStyleApplierTest {
 
     @Before
     fun setup() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         view = TextView(context)
         applier = TextViewStyleApplier(view)
         builder = TextViewStyleApplier.StyleBuilder()
@@ -238,5 +238,13 @@ class TextViewStyleApplierTest {
     fun drawablePaddingXml() {
         applier.apply(R.style.Test_TextViewStyleApplier_DrawablePadding)
         assertEquals(10, view.compoundDrawablePadding)
+    }
+
+    @Config(sdk = [28])
+    @Test
+    fun lineHeight() {
+        val lineHeight = 16
+        applier.apply(builder.lineHeight(lineHeight).build())
+        assertEquals(lineHeight, view.lineHeight)
     }
 }

--- a/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewStyleBuilderTest.kt
+++ b/paris/src/testDebug/java/com/airbnb/paris/proxies/TextViewStyleBuilderTest.kt
@@ -6,6 +6,7 @@ import android.text.InputType
 import android.view.View
 import android.widget.TextView
 import android.widget.TextViewStyleApplier
+import androidx.test.core.app.ApplicationProvider
 import com.airbnb.paris.R
 import com.airbnb.paris.attribute_values.ResourceId
 import com.airbnb.paris.styles.ProgrammaticStyle
@@ -14,7 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class TextViewStyleBuilderTest {
@@ -25,7 +26,7 @@ class TextViewStyleBuilderTest {
 
     @Before
     fun setup() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         view = TextView(context)
         builder = TextViewStyleApplier.StyleBuilder()
     }
@@ -150,5 +151,17 @@ class TextViewStyleBuilderTest {
                 .build(),
             style
         )
+    }
+
+    @Config(sdk = [28])
+    @Test
+    fun lineHeight() {
+        val lineHeight = 16
+        val style = builder.lineHeight(lineHeight).build()
+
+        assertEquals(ProgrammaticStyle.builder()
+            .put(android.R.attr.lineHeight, lineHeight)
+            .build(),
+            style)
     }
 }


### PR DESCRIPTION
This adds support for `lineHeight` in `TextView`. This isn't terribly useful because of it's minApi being 28. It has been backported in `AppCompatTextView` and if you're okay with that, I would like to add support for that. 

This also updates Robolectric to 4.1. This was needed to add tests for `lineHeight` that required api 28. The usage of `RuntimeEnvironment.application` has been deprecated and must be replaced with `ApplicationProvider.getApplicationContext()`. More on migration [here](http://robolectric.org/migrating/#migrating-to-40). 

I've only removed instances of `RuntimeEnvironment` in the tests affected so far. Can create a new issue to replace all instances and update it fully. 