### PR TITLE
Fix ArrayOutOfBoundsException on setting scale type for certain devices

### DIFF
--- a/paris/src/main/java/com/airbnb/paris/proxies/ImageViewProxy.kt
+++ b/paris/src/main/java/com/airbnb/paris/proxies/ImageViewProxy.kt
@@ -16,8 +16,11 @@ class ImageViewProxy(view: ImageView) : BaseProxy<ImageViewProxy, ImageView>(vie
     // TODO Provide a builder-only method
     @Attr(R2.styleable.Paris_ImageView_android_scaleType)
     fun setScaleType(index: Int) {
-        if (index >= 0) {
-            view.scaleType = SCALE_TYPE_ARRAY[index]
+        view.scaleType = when (index) {
+            in SCALE_TYPE_ARRAY.indices -> SCALE_TYPE_ARRAY[index]
+            // Default scale type for an ImageView
+            // https://stackoverflow.com/questions/2951923/whats-the-default-scaletype-of-imageview
+            else -> ScaleType.FIT_CENTER
         }
     }
 


### PR DESCRIPTION
This PR fixes the `ArrayOutOfBoundsException` that happens when the scale type is set on certain devices, specifically the Meitu devices. This is because the scaleType enum indices on those devices is probably modified. As a quick way to fix this issue, I add a check to ensure that the index passed to the `setScaleType` method is in the right range.

@elihart @BenSchwab 