### PR TITLE
Prepare for release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.2
+
+Bump XProcessing, KSP, and Kotlin versions to latest.
+
+There was a breaking change in the room compiler processing library, this version is compatible with Room 2.6.0-alpha01 and will fail if earlier versions are used.
+This dependency must be the same for all other annotation processors that also use this library, such as Epoxy.
+
 # 2.0.1
 
 Bump XProcessing, KSP, and Kotlin versions to latest.

--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -21,8 +21,8 @@ rootProject.ext {
     MOCKITO_VERSION = '3.11.2'
     ROBOLECTRIC_VERSION = '4.6.1'
     TESTING_COMPILE_VERSION = '0.19'
-    KOTLIN_TESTING_COMPILE_VERSION = '1.4.9'
-    XPROCESSING_VERSION = "2.5.0-alpha02"
+    KOTLIN_TESTING_COMPILE_VERSION = '1.5.0'
+    XPROCESSING_VERSION = "2.6.0-alpha01"
 
     deps = [
             // Keep these alphabetized

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
-        ANDROID_PLUGIN_VERSION = '7.2.1'
+        ANDROID_PLUGIN_VERSION = '7.4.0'
         BUTTERKNIFE_VERSION = '10.2.3'
-        KOTLIN_VERSION = '1.7.0'
+        KOTLIN_VERSION = '1.8.10'
         // Run "./gradlew dependencyUpdates" to check for updates
         VERSIONS_VERSION = '0.42.0'
-        KSP_VERSION = '1.7.0-1.0.6'
+        KSP_VERSION = '1.8.10-1.0.9'
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.1.0-SNAPSHOT
+VERSION_NAME=2.0.2
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Paris is a system for creating and applying styles to views in Android.
 POM_URL=https://github.com/airbnb/paris

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/paris-processor/src/main/java/com/airbnb/paris/processor/BaseProcessor.kt
+++ b/paris-processor/src/main/java/com/airbnb/paris/processor/BaseProcessor.kt
@@ -66,7 +66,7 @@ abstract class BaseProcessor(var kspEnvironment: SymbolProcessorEnvironment? = n
 
     final override fun process(resolver: Resolver): List<KSAnnotated> {
         val kspEnvironment = requireNotNull(kspEnvironment)
-        environment = XProcessingEnv.create(kspEnvironment.options, resolver, kspEnvironment.codeGenerator, kspEnvironment.logger)
+        environment = XProcessingEnv.create(kspEnvironment, resolver)
         process(environment, XRoundEnv.create(environment))
         return emptyList()
     }

--- a/paris-test/src/test/resources/style_extension_generation/output/MyViewStyleExtensions.kt
+++ b/paris-test/src/test/resources/style_extension_generation/output/MyViewStyleExtensions.kt
@@ -1,6 +1,6 @@
 @file:Suppress(
   "DEPRECATION",
-  "Detekt.MaxLineLength"
+  "Detekt.MaxLineLength",
 )
 
 package com.airbnb.paris.extensions

--- a/paris-test/src/test/resources/style_extension_generation_java/output/MyViewStyleExtensions.kt
+++ b/paris-test/src/test/resources/style_extension_generation_java/output/MyViewStyleExtensions.kt
@@ -1,6 +1,6 @@
 @file:Suppress(
   "DEPRECATION",
-  "Detekt.MaxLineLength"
+  "Detekt.MaxLineLength",
 )
 
 package com.airbnb.paris.extensions

--- a/paris-test/src/test/resources/style_extension_generation_jvm_static/output/MyViewStyleExtensions.kt
+++ b/paris-test/src/test/resources/style_extension_generation_jvm_static/output/MyViewStyleExtensions.kt
@@ -1,6 +1,6 @@
 @file:Suppress(
   "DEPRECATION",
-  "Detekt.MaxLineLength"
+  "Detekt.MaxLineLength",
 )
 
 package com.airbnb.paris.extensions


### PR DESCRIPTION
# 2.0.2

Bump XProcessing, KSP, and Kotlin versions to latest.

There was a breaking change in the room compiler processing library, this version is compatible with Room 2.6.0-alpha01 and will fail if earlier versions are used.
This dependency must be the same for all other annotation processors that also use this library, such as Epoxy.