### PR TITLE
Upgrade gradle-maven-publish-plugin to 0.34.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         classpath "com.jakewharton:butterknife-gradle-plugin:$BUTTERKNIFE_VERSION"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath "com.github.ben-manes:gradle-versions-plugin:$VERSIONS_VERSION"
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
         // Dokka is needed on classpath for vanniktech publish plugin
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.0"
     }


### PR DESCRIPTION
This is the current version of this plugin.

We were previously using version 0.14.2, but support for POM_LICENSE_* properties wasn't introduced until version 0.16.0. That explains why we stopped publishing license metadata between Paris version 1.4.0 and 1.5.0 (when we moved to gradle-maven-publish-plugin).

https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md