### PR TITLE
Produce Java 11-compatible bytecode

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -1,5 +1,5 @@
 rootProject.ext.JAVA_SOURCE_VERSION = JavaVersion.VERSION_17
-rootProject.ext.JAVA_TARGET_VERSION = JavaVersion.VERSION_17
+rootProject.ext.JAVA_TARGET_VERSION = JavaVersion.VERSION_11
 
 rootProject.ext {
     TARGET_SDK_VERSION = 32

--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -1,4 +1,4 @@
-rootProject.ext.JAVA_SOURCE_VERSION = JavaVersion.VERSION_17
+rootProject.ext.JAVA_SOURCE_VERSION = JavaVersion.VERSION_11
 rootProject.ext.JAVA_TARGET_VERSION = JavaVersion.VERSION_11
 
 rootProject.ext {

--- a/paris-annotations/build.gradle
+++ b/paris-annotations/build.gradle
@@ -7,7 +7,7 @@ targetCompatibility = rootProject.JAVA_TARGET_VERSION
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 

--- a/paris-processor/build.gradle
+++ b/paris-processor/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         freeCompilerArgs += "-Xopt-in=kotlin.contracts.ExperimentalContracts"
         freeCompilerArgs += "-Xopt-in=androidx.room.compiler.processing.ExperimentalProcessingApi"

--- a/paris-test-lib/build.gradle
+++ b/paris-test-lib/build.gradle
@@ -19,7 +19,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 

--- a/paris-test/build.gradle
+++ b/paris-test/build.gradle
@@ -24,7 +24,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 

--- a/paris/build.gradle
+++ b/paris/build.gradle
@@ -36,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,7 +23,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '11'
     }
 }
 


### PR DESCRIPTION
We can continue using the Java 17 toolchain, but it's helpful to roll back to the Java 11 bytecode target for broader compatibility.